### PR TITLE
Fix install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,26 @@ Query Mail is written in PHP based on a popular framework called [FuelPHP](http:
 
 The project use a SQLite preconfigured database so there is minimal dependencies.
 
+## Installation via composer
+
+```
+composer create-project querymail/querymail
+```
+ 
 ## Installation with docker
+ 
+ In order to run this project properly, the easiest way is to use the provided docker installation.
+ 
+ Edit the `docker/ssmtp.conf` file and set your mail server credentials.
+ Then simply run the `docker.sh` file at the root path of the project. This assume that you have docker installed on your machine.
+ This script will create a docker container for PHP and run a nginx webserver.
+ Add the following line in your `/etc/hosts` file : 
+ ```
+ 127.0.0.1 querymail
+ ```
+ 
+ Then you can directly access Query Mail via http://querymail
 
-In order to run this project properly, the easiest way is to use the provided docker installation.
-
-Edit the `docker/ssmtp.conf` file and set your mail server credentials.
-Then simply run the `docker.sh` file at the root path of the project. This assume that you have docker installed on your machine.
-This script will create a docker container for PHP and run a nginx webserver.
-Add the following line in your `/etc/hosts` file : 
-```
-127.0.0.1 querymail
-```
-
-Then you can directly access Query Mail via http://querymail
 
 ## Other installation
 

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "license": "MIT",
     "require": {
         "php": "^5.4 || ^7.0",
-        "ext-pdo_mysql": ">=1.0",
-        "ext-pdo_sqlite": ">=1.0",
-        "ext-gd": ">=1.0",
+        "ext-pdo_mysql": "*",
+        "ext-pdo_sqlite": "*",
+        "ext-gd": "*",
         "composer/installers": "~1.0",
         "fuel/core": "~1.8.0",
         "fuel/email": "~1.8.0",
@@ -32,7 +32,11 @@
         }
     },
     "scripts": {
-        "phpcs": "phpcs fuel/app/classes --standard=PSR2 --report-checkstyle=build/logs/checkstyle.xml"
+        "phpcs": "phpcs fuel/app/classes --standard=PSR2 --report-checkstyle=build/logs/checkstyle.xml",
+        "installdb": [
+            "if [ ! -f sqlite/querymail ]; then php -r \"\\$db = new PDO('sqlite:'.__DIR__.'/sqlite/querymail'); foreach (explode(';', file_get_contents(__DIR__.'/sqlite/querymail.sql')) as \\$line) { if (!empty(\\$line)) \\$db->exec(\\$line); }\"; fi"
+        ],
+        "post-install-cmd": "@installdb"
     },
     "minimum-stability": "stable"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "antoinevdsk/querymail",
+    "name": "querymail/querymail",
     "type": "project",
-    "description" : "Query Mail is an simple and powerful tools that generate fancy emails for reporting, statistics or monitoring your data.",
+    "description" : "Query Mail is a simple and powerful tools that generate fancy emails for reporting, statistics or monitoring your data.",
     "keywords": ["application", "website", "KPI", "mail", "database", "analytics"],
     "license": "MIT",
     "require": {
@@ -21,6 +21,11 @@
     "require-dev": {
         "fuel/docs": "1.8.*",
         "squizlabs/php_codesniffer": "^2.6"
+    },
+    "homepage": "https://github.com/antoinevdsk/querymail",
+    "support": {
+        "issues": "https://github.com/antoinevdsk/querymail/issues",
+        "source": "https://github.com/antoinevdsk/querymail"
     },
     "config": {
         "vendor-dir": "fuel/vendor"

--- a/docker.sh
+++ b/docker.sh
@@ -23,12 +23,6 @@ docker run --name querymail-php \
 title "Installing libraries"
 docker exec querymail-php bash -c "wget https://raw.githubusercontent.com/composer/getcomposer.org/1b137f8bf6db3e79a38a5bc45324414a6b1f9df2/web/installer -O - -q | php -- --quiet && mv composer.phar /usr/bin/composer && cd /srv/http && composer install --no-dev -o"
 
-
-if [ ! -f $parent_path/sqlite/querymail ]; then
-    title "Installing database"
-    docker exec querymail-php bash -c "sqlite3 /srv/http/sqlite/querymail < /srv/http/sqlite/querymail.sql"
-fi
-
 title "Nginx container"
 docker rm -f querymail-nginx 2> /dev/null
 docker run --name querymail-nginx \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,8 +11,7 @@ RUN apt-get update \
     libjpeg62-turbo-dev \
     libmcrypt-dev \
     libpng12-dev \
-    wget \
-    sqlite3
+    wget
 
 # php extension
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/


### PR DESCRIPTION
Will try to install DB after each "composer install". Would be better to use composer post-create-project-cmd instead but it's mandatory to determine if querymail should work only with docker